### PR TITLE
MASTER OF THE CURSOR

### DIFF
--- a/lua/dingllm.lua
+++ b/lua/dingllm.lua
@@ -115,8 +115,8 @@ local function get_prompt(opts)
   if visual_lines then
     prompt = table.concat(visual_lines, '\n')
     if replace then
-      vim.api.nvim_command 'normal! d'
-      vim.api.nvim_command 'normal! k'
+      vim.api.nvim_command 'normal! dO'
+      
     else
       vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes('<Esc>', false, true, true), 'nx', false)
     end


### PR DESCRIPTION
in visual line replace mode delete ten move cursor u one line and write . now fix: no more jumping line the cursor will start at begining of line